### PR TITLE
Use FFmpeg for control example video recording

### DIFF
--- a/examples/zed_oc_control_example.cpp
+++ b/examples/zed_oc_control_example.cpp
@@ -27,6 +27,8 @@
 #include <opencv2/opencv.hpp>
 #include <ctime>
 #include <sys/stat.h>
+#include <cstdio>
+#include <sstream>
 // <---- Includes
 
 // ----> Camera settings control
@@ -106,9 +108,10 @@ bool autoWB=false;
 bool applyAECAGCrectLeft=false;
 bool applyAECAGCrectRight=false;
 bool enableRecord = false;
-std::string recordFolder = "build/zed_output/";
+std::string recordFolder = "build/output/zed_oc_control_example/";
 bool writerInitialized = false;
-cv::VideoWriter videoWriter;
+FILE* ffmpegLeft = nullptr;
+FILE* ffmpegRight = nullptr;
 // <---- Global variables
 
 // The main function
@@ -184,15 +187,34 @@ int main(int argc, char *argv[])
         {
             time_t raw_t = time(nullptr);
             struct tm* t = localtime(&raw_t);
-            char name[64];
-            strftime(name, sizeof(name), "test_zed_oc_control_example_%Y-%m-%d_%H-%M-%S.mp4", t);
-            std::string filePath = recordFolder + name;
-            videoWriter.open(filePath,
-                             cv::VideoWriter::fourcc('a','v','c','1'),
-                             static_cast<int>(params.fps),
-                             cv::Size(frame.width, frame.height));
-            if(!videoWriter.isOpened())
-                std::cerr << "Unable to open VideoWriter at " << filePath << std::endl;
+            char leftName[64];
+            char rightName[64];
+            strftime(leftName, sizeof(leftName), "left_%Y-%m-%d_%H-%M-%S.mp4", t);
+            strftime(rightName, sizeof(rightName), "right_%Y-%m-%d_%H-%M-%S.mp4", t);
+            std::string leftPath = recordFolder + leftName;
+            std::string rightPath = recordFolder + rightName;
+
+            std::stringstream leftCmd;
+            std::stringstream rightCmd;
+            int halfWidth = frame.width / 2;
+            int height = frame.height;
+            int fps = static_cast<int>(params.fps);
+            leftCmd << "ffmpeg -loglevel error -y -f rawvideo -pix_fmt bgr24 -s "
+                    << halfWidth << "x" << height
+                    << " -r " << fps << " -i - -c:v libx264 -pix_fmt yuv420p \""
+                    << leftPath << "\"";
+
+            rightCmd << "ffmpeg -loglevel error -y -f rawvideo -pix_fmt bgr24 -s "
+                     << halfWidth << "x" << height
+                     << " -r " << fps << " -i - -c:v libx264 -pix_fmt yuv420p \""
+                     << rightPath << "\"";
+
+            ffmpegLeft = popen(leftCmd.str().c_str(), "w");
+            ffmpegRight = popen(rightCmd.str().c_str(), "w");
+            if(!ffmpegLeft || !ffmpegRight)
+            {
+                std::cerr << "Unable to open ffmpeg pipes" << std::endl;
+            }
             else
                 writerInitialized = true;
         }
@@ -241,9 +263,13 @@ int main(int argc, char *argv[])
             cv::cvtColor(frameYUV,frameBGR,cv::COLOR_YUV2BGR_YUYV);
             // <---- Conversion from YUV 4:2:2 to BGR for visualization
 
-            if(enableRecord && writerInitialized && videoWriter.isOpened())
+            if(enableRecord && writerInitialized && ffmpegLeft && ffmpegRight)
             {
-                videoWriter.write(frameBGR);
+                int halfWidth = frame.width / 2;
+                cv::Mat leftImg(frameBGR, cv::Rect(0, 0, halfWidth, frame.height));
+                cv::Mat rightImg(frameBGR, cv::Rect(halfWidth, 0, halfWidth, frame.height));
+                fwrite(leftImg.data, 1, leftImg.total()*leftImg.elemSize(), ffmpegLeft);
+                fwrite(rightImg.data, 1, rightImg.total()*rightImg.elemSize(), ffmpegRight);
             }
 
             // 4.c) Show frame
@@ -275,8 +301,10 @@ int main(int argc, char *argv[])
         // <---- Keyboard handling
     }
 
-    if(videoWriter.isOpened())
-        videoWriter.release();
+    if(ffmpegLeft)
+        pclose(ffmpegLeft);
+    if(ffmpegRight)
+        pclose(ffmpegRight);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
- refactor `zed_oc_control_example.cpp` to use FFmpeg via pipes
- create separate left/right recordings with timestamps
- change default output directory
- adjust build/test using micromamba and xvfb

## Testing
- `cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
- `make -j$(nproc)`
- `xvfb-run -a -s "-screen 0 4416x1242x24" ./zed_open_capture_control_example --record` *(fails: no camera attached)*

------
https://chatgpt.com/codex/tasks/task_e_687c1c06d8c08328b43bde57a236ac2b